### PR TITLE
Masonry依赖冲突

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -2,5 +2,5 @@ source 'https://github.com/CocoaPods/Specs.git'
 inhibit_all_warnings!
 platform :ios, '6.0'
 
-pod 'Masonry', '~> 0.6'
+pod 'Masonry', '~> 1.0'
 


### PR DESCRIPTION
Masonry已经升级到1.0.2，绝大部分工程都已经升级。 使用'~> 0.6' pod install 会产生依赖冲突，建议更新。